### PR TITLE
Ignore Keep notes that do not include a textContent element 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,16 @@
-This script converts exported notes from Google Keep to a notes.json file that can be imported by SimpleNote.
+This script converts exported notes from Google Keep to a notes.json file that can be imported by Simplenote.
 Google Keep titles will be added as the first line in the content of the Simplenote note. 
 Google Keep labels are converted in Simplenote tags.
 
 # usage
-To export Google Keep notes as Json, see: https://takeout.google.com/.
-To import Simplenote notes as Json, open the desktop application -> file -> import -> drag and drop.
-This script is tested with python3.8. 
-In the convert.py file, enter the absolute location with Google Keep Json files. 
-From this folder, run ```python convert.py``` in your terminal.
+* To export Google Keep notes as Json, see: https://takeout.google.com/.
+Download the archive and extract the files. 
+* This script is tested with python3.8. 
+* Edit line 7 in the `convert.py` file, enter the absolute location of the folder with the Google Keep Json files. 
+* From this folder, run ```python convert.py``` in your terminal.
+* To import Json notes to Simplenote, open the desktop application at https://app.simplenote.com/ -> file -> import -> drag and drop.
+
+# notes
+* This version only converts Keep notes that are not Archived (see `convert.py` line 22).
+You can modify this line, as required. 
+* This version only converts Keep notes that include a `textContent` element (see `convert.py` line 22).

--- a/convert.py
+++ b/convert.py
@@ -19,7 +19,7 @@ aggregate_dic = {
 for filename in json_files_in_folder:
     with open(join(folder_path, filename), encoding="utf-8") as f:
         dic = json.loads(f.read())
-        if not dic['isArchived']:
+        if not dic['isArchived'] and 'textContent' in dic:
             aggregate_dic["activeNotes"].append(
                 {
                     "content": dic["title"] + "\r\n\r\n" + dic["textContent"],


### PR DESCRIPTION
Update convert.py to ignore Keep notes with no textContent element. 
Add corresponding notes to README, plus small text updates. 